### PR TITLE
docs: capitalize Windows in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # whisper_cpp_for_win
-whisper.cpp for windows
+whisper.cpp for Windows
 
 
 # Windows 11 安裝 Whisper.cpp 使用我的腳本製作 SRT YouTube 字幕


### PR DESCRIPTION
## Summary
- capitalize Windows in project description

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68abd9a99f448325a4b80ba5ca641c99