### PR TITLE
Explicit output file options for SRT generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,9 @@ def download_and_convert(url: str) -> None:
             r"D:\whisper.cpp\models\ggml-large-v3-turbo.bin",
             "-l",
             "zh",
-            "-osrt",
+            "-o",
+            "audio",
+            "--output-srt",
             "-f",
             audio_wav,
         ]


### PR DESCRIPTION
## Summary
- Replace `-osrt` with `-o audio --output-srt` so users can choose output filename
- Keep `-f audio.wav` argument for whisper-cli

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68abdccd0a8c832589d65f8148bd9cc1